### PR TITLE
Update example plugin to include doc example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Docs: Add documentation template
 ## 2.0.1
  - Add encoding: utf-8 to spec files. This can help prevent issues during testing.
 ## 2.0.0

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+Logstash provides infrastructure to automatically build documentation for this plugin. We provide a template file, index.asciidoc, where you can add documentation. The contents of this file will be converted into html and then placed with other plugin documentation in a [central location](http://www.elastic.co/guide/en/logstash/current/).
 
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For formatting config examples, you can use the asciidoc `[source,json]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
 ## Need Help?

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,58 @@
+:plugin: example
+:type: output
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Example output plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+ADD DESCRIPTION HERE
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Example Output Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-setting_name>> |{logstash-ref}/configuration-file-structure.html#boolean[boolean]|No
+| <<plugins-{type}s-{plugin}-another_setting_name>> |{logstash-ref}/configuration-file-structure.html#hash[hash]|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+output plugins.
+
+[id="plugins-{type}s-{plugin}-setting_name"]
+===== `setting_name` 
+
+  * Value type is {logstash-ref}/configuration-file-structure.html#boolean[boolean]
+  * Default value is `true`
+
+ADD DESCRIPTION HERE.
+
+[id="plugins-{type}s-{plugin}-another_setting_name"]
+===== `another_setting_name` 
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+ADD DESCRIPTION HERE.
+
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]

--- a/logstash-output-example.gemspec
+++ b/logstash-output-example.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-example'
-  s.version         = '1.0.1'
+  s.version         = '2.0.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example output does nothing."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Our example plugins show the old way of doing docs. This PR updates the boiler plate text and adds an example file for the docs.

Wasn't sure if I needed to bump the version for this, so did it anyhow.

The text for the template is taken from existing topics. Mainly you just need to make sure I didn't make a bone headed copy/paste mistake.

Fixes https://github.com/elastic/logstash/issues/8995
